### PR TITLE
Closes #189 - Enhance protocol detection logic

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -149,8 +149,8 @@ std::string get_printable_protocol_name(unsigned int protocol) {
             proto_name = "icmp";
             break;
         case 0:
-        	proto_name = "mixed";
-        	break;
+            proto_name = "mixed";
+            break;
         default:
             proto_name = "unknown";
             break;

--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -148,6 +148,9 @@ std::string get_printable_protocol_name(unsigned int protocol) {
         case IPPROTO_ICMP:
             proto_name = "icmp";
             break;
+        case 0:
+        	proto_name = "mixed";
+        	break;
         default:
             proto_name = "unknown";
             break;

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -1936,13 +1936,17 @@ unsigned int detect_attack_protocol(map_element& speed_element, direction attack
 #define my_max_on_defines(a, b) (a > b ? a : b)
 unsigned int get_max_used_protocol(uint64_t tcp, uint64_t udp, uint64_t icmp) {
     unsigned int max = my_max_on_defines(my_max_on_defines(udp, tcp), icmp);
+    unsigned int sum = udp + tcp + icmp;
 
-    if (max == tcp) {
-        return IPPROTO_TCP;
-    } else if (max == udp) {
-        return IPPROTO_UDP;
-    } else if (max == icmp) {
-        return IPPROTO_ICMP;
+    if(sum * 0.7 <= max) {
+
+        if (max == tcp) {
+            return IPPROTO_TCP;
+        } else if (max == udp) {
+            return IPPROTO_UDP;
+        } else if (max == icmp) {
+            return IPPROTO_ICMP;
+        }
     }
 
     return 0;


### PR DESCRIPTION
If one protocol type(tcp, udp. icmp) is exceeding(or equals) 70% of the packets accounted, then we will return the protocol. Otherwise 0 is returned and interpreted as an mixed protocol type.

Tested by doing SynFlood and UDP Flood at the same time. It works!