### PR TITLE
snabb: Auto-unbind the NIC from kernel/ixgbe

### DIFF
--- a/src/tests/snabb/capture2c.lua
+++ b/src/tests/snabb/capture2c.lua
@@ -22,6 +22,10 @@ ffi.cdef("void run_speed_printer();");
 
 -- Initialize a device driver
 print("Initializing NIC: "..pciaddr)
+
+local pci = require("lib.hardware.pci")
+pci.unbind_device_from_linux(pciaddr) -- make kernel/ixgbe release this device
+
 local intel10g = require("apps.intel.intel10g")
 -- Maximum buffers to avoid packet drops
 intel10g.num_descriptors = 32*1024


### PR DESCRIPTION
Tell the kernel to unbind the device that Snabb will use from its driver (e.g. ixgbe).

This is intended as a fix so that you do not have to unload other drivers and can run Snabb based ports in parallel with ixgbe/pf_ring/etc.